### PR TITLE
set collector expiry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/infrawatch/apputils v0.0.0-20201208221556-d59b03ddde31
 	github.com/json-iterator/go v1.1.10
-	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0


### PR DESCRIPTION
Prometheus collectors must be expired after all metrics have been deleted from it else Prometheus will reject new incoming metrics with the same labels