### PR TITLE
add configuration option to handlers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 base=$(pwd)
 
 PLUGIN_DIR=${PLUGIN_DIR:-"/tmp/plugins/"}
-CONTAINER_BUILD=${CONTAINER_BUILD:-"/tmp/plugins/"}
+CONTAINER_BUILD=${CONTAINER_BUILD:-false}
 
 for i in plugins/transport/*; do 
   cd "$base/$i"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,8 +10,11 @@ type configT struct {
 	HandlerErrors bool
 	Transports    []struct {
 		Name     string `validate:"required"`
-		Handlers []string
-		Config   interface{}
+		Handlers []struct {
+			Name   string `validate:"required"`
+			Config interface{}
+		} `validate:"dive"`
+		Config interface{}
 	} `validate:"dive"`
 	Applications []struct {
 		Name   string `validate:"required"`

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -18,4 +18,7 @@ type Handler interface {
 
 	//Handle parse incoming messages from the transport and write resulting metrics or events to the corresponding bus. Handlers MUST ensure that labelValues and labelKeys for metrics are always submitted int the same order
 	Handle([]byte, bool, bus.MetricPublishFunc, bus.EventPublishFunc) error
+
+	//Config a yaml object from the config file associated with this plugin is passed into this function. The plugin is responsible for handling this data
+	Config([]byte) error
 }

--- a/plugins/handler/ceilometer-events/main.go
+++ b/plugins/handler/ceilometer-events/main.go
@@ -103,6 +103,10 @@ func (c *ceilometerEventsHandler) Identify() string {
 	return "ceilometer-events"
 }
 
+func (c *ceilometerEventsHandler) Config(blob []byte) error {
+	return nil
+}
+
 //New create new collectdEventsHandler object
 func New() handler.Handler {
 	return &ceilometerEventsHandler{}

--- a/plugins/handler/ceilometer-metrics/main.go
+++ b/plugins/handler/ceilometer-metrics/main.go
@@ -222,6 +222,10 @@ func (c *ceilometerMetricHandler) Identify() string {
 	return "ceilometer-metrics"
 }
 
+func (c *ceilometerMetricHandler) Config(blob []byte) error {
+	return nil
+}
+
 //New ceilometer metric handler constructor
 func New() handler.Handler {
 	return &ceilometerMetricHandler{

--- a/plugins/handler/collectd-events/main.go
+++ b/plugins/handler/collectd-events/main.go
@@ -105,6 +105,10 @@ func (c *collectdEventsHandler) Identify() string {
 	return "collectd-events"
 }
 
+func (c *collectdEventsHandler) Config(blob []byte) error {
+	return nil
+}
+
 //New create new collectdEventsHandler object
 func New() handler.Handler {
 	return &collectdEventsHandler{}

--- a/plugins/handler/collectd-metrics/main.go
+++ b/plugins/handler/collectd-metrics/main.go
@@ -128,6 +128,12 @@ func (c *collectdMetricsHandler) writeMetrics(cdmetric *collectd.Metric, pf bus.
 	return nil
 }
 
+func (c *collectdMetricsHandler) Config(blob []byte) error {
+	return nil
+}
+
+// helper functions
+
 func validateMetric(cdmetric *collectd.Metric) bool {
 	if cdmetric.Dsnames == nil ||
 		cdmetric.Dstypes == nil ||


### PR DESCRIPTION
This happens similarily to all of the other plugins. With this change, configurations for handlers looks like the following:
```yaml
...
transports:
  - name: socket
    ...
    handlers:
      - name: <handler name>
        config:
          <handler specific configuration>
```

This adds a config function to the handler interface:

```golang
func Config([]byte) error
```